### PR TITLE
Adding backup api feature to postcode checker service

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
-POSTCODES_API_BASE_URI=http://postcodes.io/
+POSTCODES_API_PRIMARY_URI=http://postcodes.io
+POSTCODES_API_BACKUP_URI=http://postcodes.r.us

--- a/app/controllers/postcodes_controller.rb
+++ b/app/controllers/postcodes_controller.rb
@@ -8,8 +8,10 @@ class PostcodesController < ApplicationController
   include PostcodesCheckerExceptions
 
   helpers PostcodesHelper
-  set :api_client, PostcodesAPI::Client.new
-  set :service_checker, PostcodesChecker::Service.new(api_client)
+  set :service_checker, PostcodesChecker::Service.new(
+    primary_client: PostcodesAPI::Client.new(ENV["POSTCODES_API_PRIMARY_URI"]),
+    backup_client:  PostcodesAPI::Client.new(ENV["POSTCODES_API_BACKUP_URI"])
+  )
 
   get "/" do
     erb :index

--- a/app/services/postcodes_api/client.rb
+++ b/app/services/postcodes_api/client.rb
@@ -9,12 +9,15 @@ module PostcodesAPI
     include PostcodesApiExceptions
     include PostcodesCheckerExceptions
 
-    def initialize(base_uri=nil, retry_config={}, timeout=3)
-      @base_uri = base_uri || ENV["POSTCODES_API_BASE_URI"]
-      @retry_config = configure_retries.merge(retry_config)
+    attr_reader :base_uri
+
+    def initialize(base_uri, timeout=3, retry_config={})
+      @base_uri = base_uri
       @timeout = timeout
+      @retry_config = configure_retries.merge(retry_config)
     end
 
+    # consideration needed for backup api endpoint names and errors
     def lookup_postcode(postcode)
       request(verb: :get, endpoint: "postcodes/#{sanitize(postcode)}")
     rescue NotFoundError => e

--- a/spec/services/postcodes_api/client_spec.rb
+++ b/spec/services/postcodes_api/client_spec.rb
@@ -10,8 +10,8 @@ end
 
 describe PostcodesAPI do
   describe PostcodesAPI::Client do
-    let(:api_uri) { ENV["POSTCODES_API_BASE_URI"] }
-    let(:client) { PostcodesAPI::Client.new }
+    let(:api_uri) { ENV["POSTCODES_API_PRIMARY_URI"] }
+    let(:client) { PostcodesAPI::Client.new(api_uri) }
 
     let(:found_postcode) { "SE17QD" }
     let(:invalid_postcode) { "S£19%D" }

--- a/spec/services/postcodes_checker/service_spec.rb
+++ b/spec/services/postcodes_checker/service_spec.rb
@@ -4,80 +4,138 @@ require_relative '../../../app/services/postcodes_checker/service'
 require_relative '../../../app/services/postcodes_checker/exceptions'
 require_relative '../../../app/services/postcodes_api/exceptions'
 
+
 RSpec.configure do |c|
   c.include ServicesSpecHelpers
 end
 
 describe PostcodesChecker do
-  let(:api_uri) { ENV["POSTCODES_API_BASE_URI"] }
-  let(:endpoint) { "#{api_uri}/postcodes" }
-  let(:service_checker) { PostcodesChecker::Service.new(PostcodesAPI::Client.new) }
+  let(:primary_api) { ENV["POSTCODES_API_PRIMARY_URI"] }
+  let(:backup_api) { ENV["POSTCODES_API_BACKUP_URI"] }
+  let(:primary_endpoint) { "#{primary_api}/postcodes" }
+  let(:backup_endpoint) { "#{backup_api}/postcodes" }
 
+  let(:service_checker) { PostcodesChecker::Service.new }
   let(:invalid_postcode) { "S£19%D" }
   let(:allowed_postcode) { "SH24 1AB " }
   let(:not_found_postcode) { "SE19QD" }
-  let(:not_allowed_postcode) { "SE1 7QD" }
+  let(:not_allowed_postcode) { "SE17QD" }
   let(:allowed_lsoa) { "Southwark" }
   let(:not_allowed_lsoa) { "NotAllowedLsoa" }
 
+
+
   describe PostcodesChecker::Service do
+
+    def backup_lookup_response(postcode=nil, district=nil)
+      {
+        "results" => [
+          {"postcode" => postcode, "district" => district, "flat" => 1},
+          {"postcode" => postcode, "district" => district, "flat" => 2}
+        ]
+      }
+    end
+
     describe "#servicable?" do
-      context "when the postcode is invalid" do
-        it 'raises PostcodeInvalid' do
-          expect {
-            service_checker.servicable?(invalid_postcode)
-          }.to raise_error(PostcodesCheckerExceptions::PostcodeInvalid)
+
+      context "local checks" do
+        context "when the postcode is invalid" do
+          it 'raises PostcodeInvalid' do
+            expect {
+              service_checker.servicable?(invalid_postcode)
+            }.to raise_error(PostcodesCheckerExceptions::PostcodeInvalid)
+          end
+        end
+
+        context "when the postcode is allowed" do
+          it 'returns true' do
+            expect(service_checker.servicable?(allowed_postcode)).to be true
+          end
         end
       end
 
-      context "when the postcode is allowed" do
-        it 'returns true' do
-          expect(service_checker.servicable?(allowed_postcode)).to be true
+      context "remote_checks" do
+        context "when the primary api can be reached" do
+          context "when the postcode is not found" do
+            it "returns false" do
+              error_message = "Postcode not found"
+              stub_request(:get, "#{primary_endpoint}/#{not_found_postcode}")
+                .to_return(body: JSON.dump(not_found_response(error_message)), status: 404)
+
+              expect {
+                service_checker.servicable?(not_found_postcode)
+              }.to raise_error(PostcodesCheckerExceptions::PostcodeNotFound)
+            end
+          end
+
+          context "when the LSOA is allowed" do
+            let(:client_response) { postcode_lookup_response(not_allowed_postcode, allowed_lsoa) }
+            it 'returns true' do
+              stub_request(:get, "#{primary_endpoint}/#{not_allowed_postcode}")
+                .to_return(body: JSON.dump(client_response), status: 200)
+
+              expect(service_checker.servicable?(not_allowed_postcode)).to be true
+            end
+          end
+
+          context "when both the postcode and the LSOA are not allowed" do
+            let(:client_response) { postcode_lookup_response(not_found_postcode, not_allowed_lsoa) }
+            it 'retuns false' do
+              stub_request(:get, "#{primary_endpoint}/#{not_found_postcode}")
+                .to_return(body: JSON.dump(client_response), status: 200)
+
+              expect(service_checker.servicable?(not_found_postcode)).to be false
+            end
+          end
+
+          context "when the client request returns postcode invalid" do
+            it "raises PostcodeInvalid" do
+              error_message = "Invalid postcode"
+              stub_request(:get, "#{primary_endpoint}/#{invalid_postcode}")
+                .to_return(body: JSON.dump(not_found_response(error_message)), status: 404)
+
+              expect {
+                service_checker.servicable?(invalid_postcode)
+              }.to raise_error(PostcodesCheckerExceptions::PostcodeInvalid)
+            end
+          end
         end
-      end
 
-      context "when the postcode is not found" do
-        it "returns false" do
-          error_message = "Postcode not found"
-          stub_request(:get, "#{endpoint}/#{not_found_postcode}")
-            .to_return(body: JSON.dump(not_found_response(error_message)), status: 404)
+        context "when the primary api cannot be reached" do
+          context "when the backup api is successful" do
+            it 'returns true' do
+              stub_request(:get, "#{primary_endpoint}/#{not_allowed_postcode}")
+                .to_return(body: JSON.dump(internal_server_error_response), status: 500)
+              stub_request(:get, "#{backup_endpoint}/#{not_allowed_postcode}")
+                .to_return(body: JSON.dump(backup_lookup_response(not_allowed_postcode, allowed_lsoa)), status: 200)
 
-          expect {
-            service_checker.servicable?(not_found_postcode)
-          }.to raise_error(PostcodesCheckerExceptions::PostcodeNotFound)
+              expect(service_checker.servicable?(not_allowed_postcode)).to be true
+            end
+
+            it 'returns false' do
+              stub_request(:get, "#{primary_endpoint}/#{not_allowed_postcode}")
+                .to_return(body: JSON.dump(internal_server_error_response), status: 500)
+              stub_request(:get, "#{backup_endpoint}/#{not_allowed_postcode}")
+                .to_return(body: JSON.dump(backup_lookup_response(not_allowed_postcode, not_allowed_lsoa)), status: 200)
+
+              expect(service_checker.servicable?(not_allowed_postcode)).to be false
+            end
+          end
+
+          context "when the backup api is unsuccessful" do
+            it 'raises the client exception' do
+              stub_request(:get, "#{primary_endpoint}/#{not_allowed_postcode}")
+                .to_return(body: JSON.dump(internal_server_error_response), status: 500)
+              stub_request(:get, "#{backup_endpoint}/#{not_allowed_postcode}")
+                .to_return(body: JSON.dump({"error" => "Internal server error"}), status: 500)
+
+              expect {
+                service_checker.servicable?(not_allowed_postcode)
+              }.to raise_error(PostcodesApiExceptions::InternalServerError)
+            end
+          end
         end
-      end
 
-      context "when the LSOA is allowed" do
-        let(:client_response) { postcode_lookup_response(not_allowed_postcode, allowed_lsoa) }
-        it 'returns true' do
-          stub_request(:get, "#{endpoint}/#{not_found_postcode}")
-            .to_return(body: JSON.dump(client_response), status: 200)
-
-          expect(service_checker.servicable?(not_found_postcode)).to be true
-        end
-      end
-
-      context "when both the postcode and the LSOA are not allowed" do
-        let(:client_response) { postcode_lookup_response(not_found_postcode, not_allowed_lsoa) }
-        it 'retuns false' do
-          stub_request(:get, "#{endpoint}/#{not_found_postcode}")
-            .to_return(body: JSON.dump(client_response), status: 200)
-
-          expect(service_checker.servicable?(not_found_postcode)).to be false
-        end
-      end
-
-      context "when the client request returns postcode invalid" do
-        it "raises PostcodeInvalid" do
-          error_message = "Invalid postcode"
-          stub_request(:get, "#{endpoint}/#{invalid_postcode}")
-            .to_return(body: JSON.dump(not_found_response(error_message)), status: 404)
-
-          expect {
-            service_checker.servicable?(invalid_postcode)
-          }.to raise_error(PostcodesCheckerExceptions::PostcodeInvalid)
-        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,12 @@
 ENV["RACK_ENV"] = "test"
-ENV["POSTCODES_API_BASE_URI"] = "http://postcodes-testing.io"
 
 require 'rspec'
 require 'rack/test'
 require 'webmock/rspec'
 require_relative '../config/environment'
 
+ENV["POSTCODES_API_PRIMARY_URI"] = "http://postcodes.io"
+ENV["POSTCODES_API_BACKUP_URI"] = "http://postcodes.r.us"
 
 module RSpecMixin
   include Rack::Test::Methods


### PR DESCRIPTION
- added POSTCODES_API_BACKUP_URI to .env
- updated client with base_uri attr and made the param required
- updated service with primary/backup client initialize params
- added backup_loookup to get_lsoa and added a parse_lsoa method
- updated client and service specs to reflect changes
- updated postcodes controller with new initialize method for postcodes service checker